### PR TITLE
Feature: just one table

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,22 @@ $> ./gpcheckintegrity --help
 
 ## Usage
 
+Check integrity of database `<database>`. Options to filter by schema and to control parallelism available. 
+
 ```
-gpcheckintegrity [-v | --verbose] [-s | --schema <schema_name> ] {-d | --database} <database> | -A
+gpcheckintegrity [-v | --verbose] [-s | --schema <schema_name> ] [-B | --parallel <threads>] {-d | --database} <database>
 ```
+
+
+Check integrity in all the databases
+
+```
+gpcheckintegrity -A
+```
+
+
+Print help message
+
 ```
 gpcheckintegrity -h | -? | --help
 ```

--- a/gpcheckintegrity
+++ b/gpcheckintegrity
@@ -3,7 +3,7 @@
 import os
 import string
 import sys
-from threading import Thread, Lock
+from threading import Thread, Lock, BoundedSemaphore
 
 try:
     from optparse import Option, OptionParser
@@ -54,6 +54,8 @@ def print_help(option, opt, value, parser):
           "-s, --schema <schema_name> \t" \
           "    Schema name to fetch the tables from. If this option is set, gpcheckintegrity" \
           " will limit the integrity check to the tables located in this schema \n" \
+          "-B, --parallel <threads> \t"\
+          "    Number of maximum threads running at the same time. Must be a positive integer\n"
           "-d, --database <database> \t" \
           "    Name of the database to check. This option is mandatory \n" \
           "-h, -?, --help \t\t\t" \
@@ -73,6 +75,7 @@ def print_help(option, opt, value, parser):
           "Please report any bugs in https://github.com/ielizaga/gpcheckintegrity\n".format(__file__))
     parser.exit()
 
+
 def parseargs():
     # TODO: use global class to keep some variables present at all times
     parser = OptParser(option_class=OptChecker)
@@ -83,6 +86,7 @@ def parseargs():
     parser.add_option('-S', '--schema-list', type='string', dest='schema_list')
     parser.add_option('-A', '--all', action='store_true')
     parser.add_option('-d', '--database', type='string')
+    parser.add_option('-B', '--parallel', type='string')
     (options, args) = parser.parse_args()
 
     USER = os.getenv('USER')
@@ -279,7 +283,8 @@ class CheckIntegrity(Thread):
         self.tables = tables
 
     def run(self):
-        db = connect(database=self.database, host=self.hostname, port=self.port, utilityMode=True)
+        pool_semaphore.acquire()
+        db_conn = connect(database=self.database, host=self.hostname, port=self.port, utilityMode=True)
         for table in self.tables:
             try:
                 logger.info("[seg%s] {%s} Checking table %s.%s" % (
@@ -288,7 +293,7 @@ class CheckIntegrity(Thread):
                       COPY "%s"."%s"
                       TO '/dev/null'
                       ''' % (table['schema'], table['table'])
-                db.query(qry)
+                db_conn.query(qry)
             except Exception, de:
                 # TODO: better error summary report
                 logger.error('[seg%s] {%s} Failed for table %s.%s' % (
@@ -303,9 +308,10 @@ class CheckIntegrity(Thread):
                 table_lock.release()
 
                 # TODO: pygresql wraps all queries in the same cursor under the same transaction
-                db.close()
-                db = connect(database=self.database, host=self.hostname, port=self.port, utilityMode=True)
-        db.close()
+                db_conn.close()
+                db_conn = connect(database=self.database, host=self.hostname, port=self.port, utilityMode=True)
+        db_conn.close()
+        pool_semaphore.release()
 
 
 #############
@@ -321,6 +327,20 @@ if __name__ == '__main__':
     try:
         reported_tables = []
         table_lock = Lock()
+
+        if options.parallel is not None:
+            try:
+                number_of_threads = int(options.parallel)
+                if number_of_threads <= 0:
+                    logger.warn("The number of parallel threads cannot be 0 or negative... Using default value")
+                    number_of_threads = 32
+            except ValueError, ve:
+                logger.warn("Not a number specified for option -B/--parallel... Skipping")
+                number_of_threads = 32
+        else:
+            number_of_threads = 32
+
+        pool_semaphore = BoundedSemaphore(value=number_of_threads)
 
         if options.all is not None:
             for db in get_databases():

--- a/gpcheckintegrity
+++ b/gpcheckintegrity
@@ -58,6 +58,9 @@ def print_help(option, opt, value, parser):
           "    Number of maximum threads running at the same time. Must be a positive integer\n"
           "-d, --database <database> \t" \
           "    Name of the database to check. This option is mandatory \n" \
+          "-t, --table <table> \t\t"\
+          "    Name of the table (including schema) to check. It makes gpcheckintegrity to check only <table>. "\
+          "This option has no effect if -s/-S is present \n"\
           "-h, -?, --help \t\t\t" \
           "    Prints this help page \n\n" \
           "***************************************************** \n" \
@@ -86,6 +89,7 @@ def parseargs():
     parser.add_option('-S', '--schema-list', type='string', dest='schema_list')
     parser.add_option('-A', '--all', action='store_true')
     parser.add_option('-d', '--database', type='string')
+    parser.add_option('-t', '--table', type='string')
     parser.add_option('-B', '--parallel', type='string')
     (options, args) = parser.parse_args()
 
@@ -273,6 +277,25 @@ def spawn_threads(database, schema=None, is_list=False):
         thread.join()
 
 
+def spawn_thread(database, table):
+    dbids = get_gp_segment_configuration()  # get Greenplum segment information
+
+    if table is None:
+        logger.error("Trying to check integrity of None")
+        raise RuntimeError(("Table to check is None",))
+
+    threads = []
+    for dbid in dbids:
+        if dbids[dbid]['isprimary'] == 't':
+            th = CheckIntegrity((table,), dbids[dbid]['hostname'], database, dbids[dbid]['content'], dbids[dbid]['port'])
+            th.start()
+            threads.append(th)
+
+    for thread in threads:
+        logger.debug('waiting on thread %s' % thread.getName())
+        thread.join()
+
+
 class CheckIntegrity(Thread):
     def __init__(self, tables, hostname, database, content, port):
         Thread.__init__(self)
@@ -352,6 +375,9 @@ if __name__ == '__main__':
                 spawn_threads(options.database, options.schema)
             elif options.schema_list is not None:
                 spawn_threads(options.database, options.schema_list, True)
+            elif options.table is not None:
+                table_cmdline_split = string.split(options.table, '.')
+                spawn_thread(options.database, {"schema": table_cmdline_split[0], "table": table_cmdline_split[1]})
             else:
                 spawn_threads(options.database)
 


### PR DESCRIPTION
This PR provides the functionality proposed in #8. It includes a helper function `spawn_thread()` to spawn the worker threads to check a specific table. This function was added to avoid further changes in `spawn_threads()` signature.
